### PR TITLE
Duplicate metrics responses upon querying to prevent race condition

### DIFF
--- a/elastictransport/metrics.go
+++ b/elastictransport/metrics.go
@@ -92,7 +92,11 @@ func (c *Client) Metrics() (Metrics, error) {
 	m := Metrics{
 		Requests:  c.metrics.requests,
 		Failures:  c.metrics.failures,
-		Responses: c.metrics.responses,
+		Responses: make(map[int]int, len(c.metrics.responses)),
+	}
+
+	for code, num := range c.metrics.responses {
+		m.Responses[code] = num
 	}
 
 	if pool, ok := c.pool.(connectionable); ok {

--- a/elastictransport/metrics_internal_test.go
+++ b/elastictransport/metrics_internal_test.go
@@ -111,3 +111,37 @@ func TestMetrics(t *testing.T) {
 		}
 	})
 }
+
+func TestTransportPerformAndReadMetricsResponses(t *testing.T) {
+	t.Run("Read Metrics.Responses", func(t *testing.T) {
+		u, _ := url.Parse("https://foo.com/bar")
+		tp, _ := New(Config{
+			EnableMetrics: true,
+			URLs:          []*url.URL{u},
+			Transport: &mockTransp{
+				RoundTripFunc: func(req *http.Request) (*http.Response, error) { return &http.Response{Status: "MOCK"}, nil },
+			}})
+
+		ch := make(chan struct{})
+		go func() {
+			for {
+				select {
+				case <-ch:
+					break
+				default:
+					metrics, _ := tp.Metrics()
+					for range metrics.Responses {
+					}
+				}
+			}
+		}()
+
+		for i := 0; i < 100000; i++ {
+			req, _ := http.NewRequest("GET", "/abc", nil)
+			_, _ = tp.Perform(req)
+		}
+
+		ch <- struct{}{}
+		close(ch)
+	})
+}


### PR DESCRIPTION
Port of [#397](https://github.com/elastic/go-elasticsearch/pull/397) from `go-elasticsearch`