### PR TITLE
Remove redundant locks

### DIFF
--- a/elastictransport/discovery.go
+++ b/elastictransport/discovery.go
@@ -130,9 +130,7 @@ func (c *Client) getNodesInfo() ([]nodeInfo, error) {
 		return out, err
 	}
 
-	c.Lock()
 	conn, err := c.pool.Next()
-	c.Unlock()
 	// TODO(karmi): If no connection is returned, fallback to original URLs
 	if err != nil {
 		return out, err

--- a/elastictransport/elastictransport.go
+++ b/elastictransport/elastictransport.go
@@ -315,9 +315,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 		)
 
 		// Get connection from the pool
-		c.Lock()
 		conn, err = c.pool.Next()
-		c.Unlock()
 		if err != nil {
 			if c.logger != nil {
 				c.logRoundTrip(req, nil, err, time.Time{}, time.Duration(0))
@@ -359,9 +357,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 			}
 
 			// Report the connection as unsuccessful
-			c.Lock()
 			c.pool.OnFailure(conn)
-			c.Unlock()
 
 			// Retry upon decision by the user
 			if !c.disableRetry && (c.retryOnError == nil || c.retryOnError(req, err)) {
@@ -369,9 +365,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 			}
 		} else {
 			// Report the connection as succesfull
-			c.Lock()
 			c.pool.OnSuccess(conn)
-			c.Unlock()
 		}
 
 		if res != nil && c.metrics != nil {


### PR DESCRIPTION
These locks are redundant. The pool's data should be protected by pool's mutex.