### PR TITLE
[Backport 8.1] Fix URL propagation in Curl logger

### DIFF
--- a/elastictransport/logger.go
+++ b/elastictransport/logger.go
@@ -239,7 +239,10 @@ func (l *CurlLogger) LogRoundTrip(req *http.Request, res *http.Response, err err
 		}
 	}
 
-	b.WriteString(" 'http://localhost:9200")
+	b.WriteString(" '")
+	b.WriteString(req.URL.Scheme)
+	b.WriteString("://")
+	b.WriteString(req.URL.Host)
 	b.WriteString(req.URL.Path)
 	b.WriteString("?pretty")
 	if query != "" {

--- a/elastictransport/logger_internal_test.go
+++ b/elastictransport/logger_internal_test.go
@@ -277,7 +277,7 @@ func TestTransportLogger(t *testing.T) {
 			t.Fatalf("Expected 9 lines, got %d", len(lines))
 		}
 
-		if !strings.Contains(lines[0], "curl -X GET 'http://localhost:9200/abc?pretty&q=a%2Cb'") {
+		if !strings.Contains(lines[0], "curl -X GET 'http://foo/abc?pretty&q=a%2Cb'") {
 			t.Errorf("Unexpected output: %s", lines[0])
 		}
 	})


### PR DESCRIPTION
Backport #9 