### PR TITLE
Add Config.CompressRequestBodyLevel

### DIFF
--- a/elastictransport/elastictransport.go
+++ b/elastictransport/elastictransport.go
@@ -254,6 +254,10 @@ func New(cfg Config) (*Client, error) {
 		})
 	}
 
+	if client.compressRequestBodyLevel == 0 {
+		client.compressRequestBodyLevel = gzip.DefaultCompression
+	}
+
 	return &client, nil
 }
 
@@ -279,11 +283,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 	if req.Body != nil && req.Body != http.NoBody {
 		if c.compressRequestBody {
 			var buf bytes.Buffer
-			level := gzip.DefaultCompression
-			if c.compressRequestBodyLevel != 0 {
-				level = c.compressRequestBodyLevel
-			}
-			zw, err := gzip.NewWriterLevel(&buf, level)
+			zw, err := gzip.NewWriterLevel(&buf, c.compressRequestBodyLevel)
 			if err != nil {
 				fmt.Errorf("failed setting up up compress request body (level %d): %s",
 					c.compressRequestBodyLevel, err)

--- a/elastictransport/elastictransport_internal_test.go
+++ b/elastictransport/elastictransport_internal_test.go
@@ -998,9 +998,10 @@ func TestMaxRetries(t *testing.T) {
 func TestRequestCompression(t *testing.T) {
 
 	tests := []struct {
-		name            string
-		compressionFlag bool
-		inputBody       string
+		name             string
+		compressionFlag  bool
+		compressionLevel int
+		inputBody        string
 	}{
 		{
 			name:            "Uncompressed",
@@ -1008,9 +1009,15 @@ func TestRequestCompression(t *testing.T) {
 			inputBody:       "elasticsearch",
 		},
 		{
-			name:            "Compressed",
+			name:            "CompressedDefault",
 			compressionFlag: true,
 			inputBody:       "elasticsearch",
+		},
+		{
+			name:             "CompressedBestSpeed",
+			compressionFlag:  true,
+			compressionLevel: gzip.BestSpeed,
+			inputBody:        "elasticsearch",
 		},
 	}
 
@@ -1019,6 +1026,7 @@ func TestRequestCompression(t *testing.T) {
 			tp, _ := New(Config{
 				URLs:                []*url.URL{{}},
 				CompressRequestBody: test.compressionFlag,
+				CompressRequestBodyLevel: test.compressionLevel,
 				Transport: &mockTransp{
 					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
 						if req.Body == nil || req.Body == http.NoBody {


### PR DESCRIPTION
**Story / Background**
With our large number of documents to be created, enabling the request compression
gives us ~15-20x less payload to be transferred from client to ES which translates
into ~4-5x faster wall time for the whole operation.
Of course, the latter is heavily dependent on the network speed between client and ES.

Example timings from `time` (somewhat flaky)
```
real    0m5.496s
user    0m0.903s
sys     0m0.150s
```

With compression enabled, the consumed user CPU time goes up.

Go pprof (sort=cum) shows 970ms
```
flat  flat%   sum%        cum   cum%
20ms  2.06%  2.06%      460ms 47.42%  github.com/elastic/go-elasticsearch/v8/esutil.(*worker).flush
   0     0%  2.06%      240ms 24.74%  compress/flate.(*Writer).Write (inline)
```
The bulk indexer flush() function is the most heavy function (cumulated CPU).
The biggest part here is the gzip compression.

**Test results with faster compression**
Using a compression level of `gzip.BestSpeed` instead of `gzip.DefaultCompression` only slightly increases
the payload to be transferred. But the CPU usage of the compress function goes down measureably.

Example timings from `time` (somewhat flaky)
```
real    0m4.650s
user    0m0.766s
sys     0m0.171s
```

Go pprof (sort=cum) shows 870ms total
```
flat  flat%   sum%        cum   cum%
   0     0%     0%      360ms 41.38%  github.com/elastic/go-elasticsearch/v8/esutil.(*worker).flush
   0     0%  1.15%      120ms 13.79%  compress/flate.(*Writer).Write (inline)
```

Be aware that these numbers are flaky and just give a rough direction.

**Suggested Improvement**
I'd like to suggest a new configuration option to let the user configure the compression level.

`Config.CompressRequestBodyLevel` is of type `int` to be in sync with the predefined gzip levels.
To stay compatible with with the existing behavior, the default translates into `gzip.DefaultCompression`.

I'll also create a PR for `go-elasticsearch` to make use of the new flag.
