### PR TITLE
Clone default http.Transport if none is provided.

### DIFF
--- a/elastictransport/elastictransport.go
+++ b/elastictransport/elastictransport.go
@@ -47,13 +47,11 @@ var (
 )
 
 // Interface defines the interface for HTTP client.
-//
 type Interface interface {
 	Perform(*http.Request) (*http.Response, error)
 }
 
 // Config represents the configuration of HTTP client.
-//
 type Config struct {
 	UserAgent string
 
@@ -83,7 +81,7 @@ type Config struct {
 	MaxRetries   int
 	RetryBackoff func(attempt int) time.Duration
 
-	CompressRequestBody bool
+	CompressRequestBody      bool
 	CompressRequestBodyLevel int
 
 	EnableMetrics     bool
@@ -101,7 +99,6 @@ type Config struct {
 }
 
 // Client represents the HTTP client.
-//
 type Client struct {
 	sync.Mutex
 
@@ -125,7 +122,7 @@ type Client struct {
 	discoverNodesInterval time.Duration
 	discoverNodesTimer    *time.Timer
 
-	compressRequestBody bool
+	compressRequestBody      bool
 	compressRequestBodyLevel int
 
 	metrics *metrics
@@ -140,10 +137,13 @@ type Client struct {
 // New creates new transport client.
 //
 // http.DefaultTransport will be used if no transport is passed in the configuration.
-//
 func New(cfg Config) (*Client, error) {
 	if cfg.Transport == nil {
-		cfg.Transport = http.DefaultTransport
+		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return nil, errors.New("cannot clone http.DefaultTransport")
+		}
+		cfg.Transport = defaultTransport.Clone()
 	}
 
 	if transport, ok := cfg.Transport.(*http.Transport); ok {
@@ -218,7 +218,7 @@ func New(cfg Config) (*Client, error) {
 		retryBackoff:          cfg.RetryBackoff,
 		discoverNodesInterval: cfg.DiscoverNodesInterval,
 
-		compressRequestBody: cfg.CompressRequestBody,
+		compressRequestBody:      cfg.CompressRequestBody,
 		compressRequestBodyLevel: cfg.CompressRequestBodyLevel,
 
 		transport: cfg.Transport,
@@ -262,7 +262,6 @@ func New(cfg Config) (*Client, error) {
 }
 
 // Perform executes the request and returns a response or error.
-//
 func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 	var (
 		res *http.Response
@@ -437,8 +436,6 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 }
 
 // URLs returns a list of transport URLs.
-//
-//
 func (c *Client) URLs() []*url.URL {
 	return c.pool.URLs()
 }


### PR DESCRIPTION
Use a clone of the http.DefaultTransport.(*http.Transport) if no transport is provided to avoid collisions.

Fix #11 