### PR TITLE
Fix retry with URL prefix

### DIFF
--- a/elastictransport/elastictransport.go
+++ b/elastictransport/elastictransport.go
@@ -317,6 +317,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 		}
 	}
 
+	originalPath := req.URL.Path
 	for i := 0; i <= c.maxRetries; i++ {
 		var (
 			conn            *Connection
@@ -429,6 +430,10 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 				break
 			}
 		}
+
+		// Re-init the path of the request to its original state
+		// This will be re-enriched by the connection upon retry
+		req.URL.Path = originalPath
 	}
 
 	// TODO(karmi): Wrap error


### PR DESCRIPTION
Retry with a prefix currently readds the prefix to each subsequent request, different servers in the pool could have different url prefix. We re-init the path to the original request between retries to allow proper re-update.

Port of https://github.com/elastic/go-elasticsearch/pull/657