### PR TITLE
[Performance Improvement] Pool `gzip.Writer` and `bytes.Buffer`

### DIFF
--- a/elastictransport/elastictransport.go
+++ b/elastictransport/elastictransport.go
@@ -88,7 +88,8 @@ type Config struct {
 
 	CompressRequestBody      bool
 	CompressRequestBodyLevel int
-	PoolCompressor           bool
+	// If PoolCompressor is true, a sync.Pool based gzip writer is used. Should be enabled with CompressRequestBody.
+	PoolCompressor bool
 
 	EnableMetrics     bool
 	EnableDebugLogger bool

--- a/elastictransport/elastictransport.go
+++ b/elastictransport/elastictransport.go
@@ -314,7 +314,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 			gzipWriter := c.newGzipWriter()
 			if gzipWriter.err != nil {
 				return nil, fmt.Errorf("failed setting up up compress request body (level %d): %s",
-					c.compressRequestBodyLevel, err)
+					c.compressRequestBodyLevel, gzipWriter.err)
 			}
 			defer c.gzipWriterPool.Put(gzipWriter)
 

--- a/elastictransport/elastictransport_internal_test.go
+++ b/elastictransport/elastictransport_internal_test.go
@@ -1013,6 +1013,7 @@ func TestRequestCompression(t *testing.T) {
 		name             string
 		compressionFlag  bool
 		compressionLevel int
+		poolCompressor   bool
 		inputBody        string
 	}{
 		{
@@ -1031,6 +1032,12 @@ func TestRequestCompression(t *testing.T) {
 			compressionLevel: gzip.BestSpeed,
 			inputBody:        "elasticsearch",
 		},
+		{
+			name:            "CompressedDefault",
+			compressionFlag: true,
+			poolCompressor:  true,
+			inputBody:       "elasticsearch",
+		},
 	}
 
 	for _, test := range tests {
@@ -1039,6 +1046,7 @@ func TestRequestCompression(t *testing.T) {
 				URLs:                     []*url.URL{{}},
 				CompressRequestBody:      test.compressionFlag,
 				CompressRequestBodyLevel: test.compressionLevel,
+				PoolCompressor:           test.poolCompressor,
 				Transport: &mockTransp{
 					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
 						if req.Body == nil || req.Body == http.NoBody {

--- a/elastictransport/gzip.go
+++ b/elastictransport/gzip.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package elastictransport
 
 import (

--- a/elastictransport/gzip.go
+++ b/elastictransport/gzip.go
@@ -1,0 +1,110 @@
+package elastictransport
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"sync"
+)
+
+type gzipCompressor interface {
+	// compress compresses the given io.ReadCloser and returns the gzip compressed data as a bytes.Buffer.
+	compress(io.ReadCloser) (*bytes.Buffer, error)
+	// collectBuffer collects the given bytes.Buffer for reuse.
+	collectBuffer(*bytes.Buffer)
+}
+
+// simpleGzipCompressor is a simple implementation of gzipCompressor that creates a new gzip.Writer for each call.
+type simpleGzipCompressor struct {
+	compressionLevel int
+}
+
+func newSimpleGzipCompressor(compressionLevel int) gzipCompressor {
+	return &simpleGzipCompressor{
+		compressionLevel: compressionLevel,
+	}
+}
+
+func (sg *simpleGzipCompressor) compress(rc io.ReadCloser) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+	zw, err := gzip.NewWriterLevel(&buf, sg.compressionLevel)
+	if err != nil {
+		return nil, fmt.Errorf("failed setting up up compress request body (level %d): %s",
+			sg.compressionLevel, err)
+	}
+
+	if _, err = io.Copy(zw, rc); err != nil {
+		return nil, fmt.Errorf("failed to compress request body: %s", err)
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("failed to compress request body (during close): %s", err)
+	}
+	return &buf, nil
+}
+
+func (sg *simpleGzipCompressor) collectBuffer(buf *bytes.Buffer) {
+	// no-op
+}
+
+type pooledGzipCompressor struct {
+	gzipWriterPool   *sync.Pool
+	bufferPool       *sync.Pool
+	compressionLevel int
+}
+
+type gzipWriter struct {
+	writer *gzip.Writer
+	err    error
+}
+
+// newPooledGzipCompressor returns a new pooledGzipCompressor that uses a sync.Pool to reuse gzip.Writers.
+func newPooledGzipCompressor(compressionLevel int) gzipCompressor {
+	gzipWriterPool := sync.Pool{
+		New: func() any {
+			writer, err := gzip.NewWriterLevel(io.Discard, compressionLevel)
+			return &gzipWriter{
+				writer: writer,
+				err:    err,
+			}
+		},
+	}
+
+	bufferPool := sync.Pool{
+		New: func() any {
+			return new(bytes.Buffer)
+		},
+	}
+
+	return &pooledGzipCompressor{
+		gzipWriterPool:   &gzipWriterPool,
+		bufferPool:       &bufferPool,
+		compressionLevel: compressionLevel,
+	}
+}
+
+func (pg *pooledGzipCompressor) compress(rc io.ReadCloser) (*bytes.Buffer, error) {
+	writer := pg.gzipWriterPool.Get().(*gzipWriter)
+	defer pg.gzipWriterPool.Put(writer)
+
+	if writer.err != nil {
+		return nil, fmt.Errorf("failed setting up up compress request body (level %d): %s",
+			pg.compressionLevel, writer.err)
+	}
+
+	buf := pg.bufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	writer.writer.Reset(buf)
+
+	if _, err := io.Copy(writer.writer, rc); err != nil {
+		return nil, fmt.Errorf("failed to compress request body: %s", err)
+	}
+	if err := writer.writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed to compress request body (during close): %s", err)
+	}
+	return buf, nil
+}
+
+func (pg *pooledGzipCompressor) collectBuffer(buf *bytes.Buffer) {
+	pg.bufferPool.Put(buf)
+}


### PR DESCRIPTION
## Summary
Added `sync.Pool` to pool `gzip.Writer` and `bytes.Buffer` for better performance.

## Background
While I was investigating profile report of my application, noticed transport client is not pooling gzip writer and buffer.
As discussed in [this Reddit thread](https://www.reddit.com/r/golang/comments/9uejp4/usage_of_syncpool_for_gzipwriter_in_http_handlers/) and many other places, pooling them will benefit us by reusing allocated memory space rather than allocating and freeing them on every request.

## Performance Comparison
These are the benchmark result on my machine (Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz)

### Compress body 
|                        | ns/op  | B/op   | allocs/op |
| ---------------------- | ------ | ------ | --------- |
| Before                 | 129744 | 815064 | 32        |
| After(Without pooling) | 117462 | 815014 | 31        |
| After(With poolong)    | 20462  | 1152   | 12        |

bench result
```
Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^BenchmarkTransport$ github.com/elastic/elastic-transport-go/v8/elastictransport

goos: darwin
goarch: amd64
pkg: github.com/elastic/elastic-transport-go/v8/elastictransport
cpu: Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz

=== RUN   BenchmarkTransport/Compress_body_(pool:_false)
BenchmarkTransport/Compress_body_(pool:_false)
BenchmarkTransport/Compress_body_(pool:_false)-8                    9450            117462 ns/op          815014 B/op         31 allocs/op
=== RUN   BenchmarkTransport/Compress_body_(pool:_true)
BenchmarkTransport/Compress_body_(pool:_true)
BenchmarkTransport/Compress_body_(pool:_true)-8                    57690             20462 ns/op            1152 B/op         12 allocs/op

====================
=== before the change ===
====================

=== RUN   BenchmarkTransport/Compress_body
BenchmarkTransport/Compress_body
BenchmarkTransport/Compress_body-8                    9697            129744 ns/op          815064 B/op         32 allocs/op
```