### PR TITLE
Updatable connection pool

### DIFF
--- a/elastictransport/connection.go
+++ b/elastictransport/connection.go
@@ -232,17 +232,28 @@ func (cp *statusConnectionPool) Update(connections []*Connection) error {
 				break
 			}
 		}
-		for _, dead := range cp.dead {
-			if cp.live[i].Cmp(dead) {
-				found = false
-				break
-			}
-		}
 
 		if !found {
 			// Remove item; https://github.com/golang/go/wiki/SliceTricks
 			copy(cp.live[i:], cp.live[i+1:])
 			cp.live = cp.live[:len(cp.live)-1]
+			i--
+		}
+	}
+
+	// Remove hosts that are no longer in the dead list of connections
+	for i := 0; i < len(cp.dead); i++ {
+		found := false
+		for _, c := range connections {
+			if cp.dead[i].Cmp(c) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			copy(cp.dead[i:], cp.dead[i+1:])
+			cp.dead = cp.dead[:len(cp.dead)-1]
 			i--
 		}
 	}

--- a/elastictransport/connection.go
+++ b/elastictransport/connection.go
@@ -219,6 +219,10 @@ func (cp *statusConnectionPool) OnFailure(c *Connection) error {
 // Update merges the existing live and dead connections with the latest nodes discovered from the cluster.
 // ConnectionPool must be locked before calling.
 func (cp *statusConnectionPool) Update(connections []*Connection) error {
+	if len(connections) == 0 {
+		return errors.New("no connections provided, connection pool left untouched")
+	}
+
 	// Remove hosts that are no longer in the new list of connections
 	for i := 0; i < len(cp.live); i++ {
 		found := false

--- a/elastictransport/connection.go
+++ b/elastictransport/connection.go
@@ -117,9 +117,6 @@ func (cp *singleConnectionPool) OnSuccess(c *Connection) error { return nil }
 // OnFailure is a no-op for single connection pool.
 func (cp *singleConnectionPool) OnFailure(c *Connection) error { return nil }
 
-// Update is a no-op for single connection pool.
-func (cp *singleConnectionPool) Update([]*Connection) error { return nil }
-
 // URLs returns the list of URLs of available connections.
 func (cp *singleConnectionPool) URLs() []*url.URL { return []*url.URL{cp.connection.URL} }
 

--- a/elastictransport/connection.go
+++ b/elastictransport/connection.go
@@ -188,16 +188,6 @@ func (cp *statusConnectionPool) OnFailure(c *Connection) error {
 	cp.scheduleResurrect(c)
 	c.Unlock()
 
-	// Push item to dead list and sort slice by number of failures
-	cp.dead = append(cp.dead, c)
-	sort.Slice(cp.dead, func(i, j int) bool {
-		c1 := cp.dead[i]
-		c2 := cp.dead[j]
-
-		res := c1.Failures > c2.Failures
-		return res
-	})
-
 	// Check if connection exists in the list, return error if not.
 	index := -1
 	for i, conn := range cp.live {
@@ -208,6 +198,16 @@ func (cp *statusConnectionPool) OnFailure(c *Connection) error {
 	if index < 0 {
 		return errors.New("connection not in live list")
 	}
+
+	// Push item to dead list and sort slice by number of failures
+	cp.dead = append(cp.dead, c)
+	sort.Slice(cp.dead, func(i, j int) bool {
+		c1 := cp.dead[i]
+		c2 := cp.dead[j]
+
+		res := c1.Failures > c2.Failures
+		return res
+	})
 
 	// Remove item; https://github.com/golang/go/wiki/SliceTricks
 	copy(cp.live[index:], cp.live[index+1:])

--- a/elastictransport/connection.go
+++ b/elastictransport/connection.go
@@ -66,7 +66,9 @@ type Connection struct {
 
 func (c *Connection) Cmp(connection *Connection) bool {
 	if c.URL.Hostname() == connection.URL.Hostname() {
-		return c.URL.Port() == connection.URL.Port()
+		if c.URL.Port() == connection.URL.Port() {
+			return c.URL.Path == connection.URL.Path
+		}
 	}
 	return false
 }

--- a/elastictransport/connection_internal_test.go
+++ b/elastictransport/connection_internal_test.go
@@ -380,14 +380,23 @@ func TestConnection(t *testing.T) {
 }
 
 func TestUpdateConnectionPool(t *testing.T) {
-	var initialConnections = []*Connection{
+	var initialConnections = []Connection{
 		{URL: &url.URL{Scheme: "http", Host: "foo1"}},
 		{URL: &url.URL{Scheme: "http", Host: "foo2"}},
 		{URL: &url.URL{Scheme: "http", Host: "foo3"}},
 	}
 
+	initConnList := func() []*Connection {
+		var conns []*Connection
+		for i := 0; i < len(initialConnections); i++ {
+			conns = append(conns, &initialConnections[i])
+		}
+
+		return conns
+	}
+
 	t.Run("Update connection pool", func(t *testing.T) {
-		pool := &statusConnectionPool{live: initialConnections}
+		pool := &statusConnectionPool{live: initConnList()}
 
 		if len(pool.URLs()) != 3 {
 			t.Fatalf("Invalid number of URLs: %d", len(pool.URLs()))
@@ -408,7 +417,7 @@ func TestUpdateConnectionPool(t *testing.T) {
 	})
 
 	t.Run("Update connection pool with dead connections", func(t *testing.T) {
-		pool := &statusConnectionPool{live: initialConnections}
+		pool := &statusConnectionPool{live: initConnList()}
 
 		pool.dead = []*Connection{
 			{URL: &url.URL{Scheme: "http", Host: "bar1"}},
@@ -423,5 +432,82 @@ func TestUpdateConnectionPool(t *testing.T) {
 
 		fmt.Println(pool.live)
 		fmt.Println(pool.dead)
+	})
+
+	t.Run("Update connection pool lifecycle", func(t *testing.T) {
+		// Set up a test connection pool with some initial connections
+		cp := &statusConnectionPool{
+			live: initConnList(),
+		}
+		err := cp.Update(initConnList())
+		if err != nil {
+			t.Errorf("Update() returned an error: %v", err)
+		}
+
+		// Test removing a connection that's no longer present
+		connections := []*Connection{
+			{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+			{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+		}
+		err = cp.Update(connections)
+		if len(cp.live) != 2 {
+			t.Errorf("Expected only two live connection after update")
+		}
+
+		// foo1 fails
+		cp.OnFailure(cp.live[0])
+		// we update the connexion, nothing should move
+		err = cp.Update(connections)
+		if len(cp.live) != 1 {
+			t.Errorf("Expected no connections to be added to lists")
+		}
+
+		// Test adding a new connection that's not already present
+		connections = append(connections, &Connection{URL: &url.URL{Scheme: "http", Host: "foo12"}})
+		err = cp.Update(connections)
+		if len(cp.live) != 2 {
+			t.Errorf("Expected the new connection to be added to live list")
+		}
+		cp.resurrect(cp.dead[0], false)
+
+		// Test updating with an empty list of connections
+		connections = []*Connection{}
+		err = cp.Update(connections)
+		if len(cp.live) != 3 {
+			t.Errorf("Expected connections to be untouched after empty update")
+		}
+	})
+
+	t.Run("Update connection pool with discovery", func(t *testing.T) {
+		cp := &statusConnectionPool{
+			live:     initConnList(),
+			selector: &roundRobinSelector{curr: -1},
+		}
+
+		connections := []*Connection{
+			{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+			{URL: &url.URL{Scheme: "http", Host: "foo3"}},
+		}
+
+		conn, err := cp.Next()
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if conn.URL.Host != "foo1" {
+			t.Errorf("Unexpected host: %s", conn.URL.Host)
+		}
+
+		// Update happens between Next and OnFailure
+		cp.Update(connections)
+
+		// conn fails, doesn't exist in live list anymore
+		err = cp.OnFailure(conn)
+		if err == nil {
+			t.Errorf("OnFailure() returned an unexpected error")
+		}
+
+		if len(cp.dead) != 0 {
+			t.Errorf("OnFailure() should not add unknown live connections to dead list")
+		}
 	})
 }

--- a/elastictransport/connection_internal_test.go
+++ b/elastictransport/connection_internal_test.go
@@ -449,6 +449,28 @@ func TestUpdateConnectionPool(t *testing.T) {
 		fmt.Println(pool.dead)
 	})
 
+	t.Run("Update connection pool with different ports and or path", func(t *testing.T) {
+		conns := []Connection{
+			{URL: &url.URL{Scheme: "http", Host: "foo1:9200"}},
+			{URL: &url.URL{Scheme: "http", Host: "foo1:9205"}},
+			{URL: &url.URL{Scheme: "http", Host: "foo1:9200", Path: "/bar1"}},
+		}
+		pool := &statusConnectionPool{}
+		for i := 0; i < len(conns); i++ {
+			pool.live = append(pool.live, &conns[i])
+		}
+
+		tmp := []*Connection{}
+		for i := 0; i < len(conns); i++ {
+			tmp = append(tmp, &conns[i])
+		}
+		pool.Update(tmp)
+
+		if len(pool.live) != len(tmp) {
+			t.Errorf("Invalid number of connections: %d", len(pool.live))
+		}
+	})
+
 	t.Run("Update connection pool lifecycle", func(t *testing.T) {
 		// Set up a test connection pool with some initial connections
 		cp := &statusConnectionPool{

--- a/elastictransport/connection_internal_test.go
+++ b/elastictransport/connection_internal_test.go
@@ -416,6 +416,21 @@ func TestUpdateConnectionPool(t *testing.T) {
 		}
 	})
 
+	t.Run("Update connection removes unknown dead connections", func(t *testing.T) {
+		// we start with a bar1 host which shouldn't be there
+		pool := &statusConnectionPool{
+			live: initConnList(),
+			dead: []*Connection{
+				{URL: &url.URL{Scheme: "http", Host: "bar1"}},
+			},
+		}
+
+		pool.Update(initConnList())
+		if len(pool.dead) != 0 {
+			t.Errorf("Expected no dead connections, got: %s", pool.dead)
+		}
+	})
+
 	t.Run("Update connection pool with dead connections", func(t *testing.T) {
 		pool := &statusConnectionPool{live: initConnList()}
 

--- a/elastictransport/discovery.go
+++ b/elastictransport/discovery.go
@@ -30,7 +30,6 @@ import (
 )
 
 // Discoverable defines the interface for transports supporting node discovery.
-//
 type Discoverable interface {
 	DiscoverNodes() error
 }
@@ -38,7 +37,6 @@ type Discoverable interface {
 // nodeInfo represents the information about node in a cluster.
 //
 // See: https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
-//
 type nodeInfo struct {
 	ID         string
 	Name       string
@@ -51,7 +49,6 @@ type nodeInfo struct {
 }
 
 // DiscoverNodes reloads the client connections by fetching information from the cluster.
-//
 func (c *Client) DiscoverNodes() error {
 	var conns []*Connection
 
@@ -109,10 +106,16 @@ func (c *Client) DiscoverNodes() error {
 	if c.poolFunc != nil {
 		c.pool = c.poolFunc(conns, c.selector)
 	} else {
-		// TODO(karmi): Replace only live connections, leave dead scheduled for resurrect?
-		c.pool, err = NewConnectionPool(conns, c.selector)
-		if err != nil {
-			return err
+		if p, ok := c.pool.(UpdatableConnectionPool); ok {
+			err = p.Update(conns)
+			if err != nil {
+				return err
+			}
+		} else {
+			c.pool, err = NewConnectionPool(conns, c.selector)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/elastictransport/discovery.go
+++ b/elastictransport/discovery.go
@@ -109,7 +109,9 @@ func (c *Client) DiscoverNodes() error {
 		if p, ok := c.pool.(UpdatableConnectionPool); ok {
 			err = p.Update(conns)
 			if err != nil {
-				return err
+				if debugLogger != nil {
+					debugLogger.Logf("Error updating pool: %s\n", err)
+				}
 			}
 		} else {
 			c.pool, err = NewConnectionPool(conns, c.selector)


### PR DESCRIPTION
This PR introduces an `UpdatableConnectionPool` interface into the transport, primarily used in `statusConnectionPool`.

This addresses the problem highlighted in #20 related to the eventual pool swap between a call to `pool.Next` and the follow-up call to `pool.OnFailure`.
Nodes discovery could swap out the pool in between retries resulting in an unknown state for connection pool.

We now update the existing connection pool to be up to date with the latest known state provided by the cluster.