### PR TITLE
fix: add globalheader to client#getNodesInfo()

### DIFF
--- a/elastictransport/discovery.go
+++ b/elastictransport/discovery.go
@@ -146,6 +146,7 @@ func (c *Client) getNodesInfo() ([]nodeInfo, error) {
 	c.setReqURL(conn.URL, req)
 	c.setReqAuth(conn.URL, req)
 	c.setReqUserAgent(req)
+	c.setReqGlobalHeader(req)
 
 	res, err := c.transport.RoundTrip(req)
 	if err != nil {


### PR DESCRIPTION
i use go-elasticsearch to visit elasticsearch servers, and due to the restrictions of my company, i have to add a custom header to the request. go-elasticsearch config and underlying transport client config provides a **global header** field to do this thing, like the bode below
```golang
c, err := es8.NewTypedClient(es8.Config{
	Addresses:            url,
	Username:             name,
	Password:             pwd,
	DiscoverNodesOnStart: true,
	Header:               globalHeader,
})
```
it works when i just perform a search, because the underlying transport client set the global header before performing a request like this
```golang
func (c *Client) Perform(req *http.Request) (*http.Response, error) {
	var (
		res *http.Response
		err error
	)
        ...
	// Update request
	c.setReqUserAgent(req)
	c.setReqGlobalHeader(req)
        ...
}
```
`c.setReqGlobalHeader(req)` is used to set the global header.

but when it comes to discoverNodes(), the global header is not set, leading to discoverNodes failure in my case
```golang
func (c *Client) getNodesInfo() ([]nodeInfo, error) {
	var (
		out    []nodeInfo
		scheme = c.urls[0].Scheme
	)

	req, err := http.NewRequest("GET", "/_nodes/http", nil)
	...

	c.setReqURL(conn.URL, req)
	c.setReqAuth(conn.URL, req)
	c.setReqUserAgent(req)

	res, err := c.transport.RoundTrip(req)
        ...
}
```
I think this is a mistake, and this pr add `c.setReqGlobalHeader(req)` to `getNodesInfo()` to set global header
