### PR TITLE
[Feat] Include discover node timeout

### DIFF
--- a/elastictransport/discovery.go
+++ b/elastictransport/discovery.go
@@ -18,6 +18,7 @@
 package elastictransport
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -130,7 +131,17 @@ func (c *Client) getNodesInfo() ([]nodeInfo, error) {
 		scheme = c.urls[0].Scheme
 	)
 
-	req, err := http.NewRequest("GET", "/_nodes/http", nil)
+	var ctx context.Context
+	var cancel context.CancelFunc
+
+	if c.discoverNodeTimeout != nil {
+		ctx, cancel = context.WithTimeout(context.Background(), *c.discoverNodeTimeout)
+		defer cancel()
+	} else {
+		ctx = context.Background() // Use default context if no timeout is set
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "/_nodes/http", nil)
 	if err != nil {
 		return out, err
 	}

--- a/elastictransport/elastictransport.go
+++ b/elastictransport/elastictransport.go
@@ -97,6 +97,7 @@ type Config struct {
 	Instrumentation Instrumentation
 
 	DiscoverNodesInterval time.Duration
+	DiscoverNodeTimeout   *time.Duration
 
 	Transport http.RoundTripper
 	Logger    Logger
@@ -130,6 +131,7 @@ type Client struct {
 	retryBackoff          func(attempt int) time.Duration
 	discoverNodesInterval time.Duration
 	discoverNodesTimer    *time.Timer
+	discoverNodeTimeout   *time.Duration
 
 	compressRequestBody      bool
 	compressRequestBodyLevel int
@@ -239,6 +241,10 @@ func New(cfg Config) (*Client, error) {
 		poolFunc:  cfg.ConnectionPoolFunc,
 
 		instrumentation: cfg.Instrumentation,
+	}
+
+	if cfg.DiscoverNodeTimeout != nil {
+		client.discoverNodeTimeout = cfg.DiscoverNodeTimeout
 	}
 
 	if client.poolFunc != nil {


### PR DESCRIPTION

This PR is based on the following issue: [#842](https://github.com/elastic/go-elasticsearch/issues/842).

- Introduced conditional context initialization using `context.WithTimeout` when `discoverNodeTimeout` is provided.
- Ensured proper handling of context cancellation by deferring the ` cancel()` function only when a timeout is set.
- Updated the HTTP request creation to use `NewRequestWithContext` for context-aware request execution.