### PR TITLE
Conform to `GetBody()` contract for compressed request bodies 

### DIFF
--- a/elastictransport/elastictransport.go
+++ b/elastictransport/elastictransport.go
@@ -308,7 +308,9 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 			defer c.gzipCompressor.collectBuffer(buf)
 
 			req.GetBody = func() (io.ReadCloser, error) {
-				return ioutil.NopCloser(buf), nil
+				// Copy value of buf so it's not destroyed on first read
+				r := *buf
+				return ioutil.NopCloser(&r), nil
 			}
 			req.Body, _ = req.GetBody()
 
@@ -321,6 +323,7 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 				buf.ReadFrom(req.Body)
 
 				req.GetBody = func() (io.ReadCloser, error) {
+					// Copy value of buf so it's not destroyed on first read
 					r := buf
 					return ioutil.NopCloser(&r), nil
 				}


### PR DESCRIPTION
The struct definition of [http.Request](https://pkg.go.dev/net/http#Request) specifies `GetBody` as
>  	// GetBody defines an optional func to return a new copy of
	// Body. It is used for client requests when a redirect requires
	// reading the body more than once. Use of GetBody still
	// requires setting Body.

Prior to this change, `GetBody` for compressed requests would consume the buffer containing the compressed body. This is in violation of the stated contract for `GetBody`. And it has the following implications:
- Any subsequent reads of the request body through `GetBody` will get an empty `io.Reader`.
  - This means that retries with compression enabled would fail
  - Logging the request body when `CompressRequestBody: true` would fail with any `elastictransport.Logger`.
  - And any use of `GetBody` after calling `transport.RoundTrip` will fail to get the correct contents of `req.Body`

Users may notice slightly increased memory usage because we are now copying the `res.Body`, buffer. However, this is the current approach when `CompressRequestBody: false`. And it is the only way to conform to the `http.Request` required contract.


- Resolves: https://github.com/elastic/go-elasticsearch/issues/912
  - Note: After this PR is merged, if compression is enabled and `Logger.RequestBodyEnabled() == true`, the request body that is logged will be the _compressed version_. This is the simplest fix. however users may desire to log the uncompressed body. We did not attempt to implement that here because it would require a larger contract change to this library. 