### PR TITLE
feat: add a Close method to transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ The transport provides the basic layer to access Elasticsearch APIs.
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 )
@@ -37,6 +39,11 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = transport.Close(ctx)
+	}()
 
 	req, _ := http.NewRequest("GET", "/", nil)
 

--- a/elastictransport/connection.go
+++ b/elastictransport/connection.go
@@ -18,18 +18,27 @@
 package elastictransport
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
 	"net/url"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 var (
 	defaultResurrectTimeoutInitial      = 60 * time.Second
 	defaultResurrectTimeoutFactorCutoff = 5
+
+	// zero-allocation interface assertions
+	_ ConnectionPool          = (*singleConnectionPool)(nil)
+	_ ConnectionPool          = (*statusConnectionPool)(nil)
+	_ UpdatableConnectionPool = (*statusConnectionPool)(nil)
+	_ CloseableConnectionPool = (*statusConnectionPool)(nil)
+	_ Selector                = (*roundRobinSelector)(nil)
 )
 
 // Selector defines the interface for selecting connections from the pool.
@@ -47,6 +56,11 @@ type ConnectionPool interface {
 
 type UpdatableConnectionPool interface {
 	Update([]*Connection) error // Update injects newly found nodes in the cluster.
+}
+
+// CloseableConnectionPool defines the interface for the connection pool that can be closed.
+type CloseableConnectionPool interface {
+	Close(context.Context) error
 }
 
 // Connection represents a connection to a node.
@@ -87,6 +101,10 @@ type statusConnectionPool struct {
 	selector Selector
 
 	metrics *metrics
+
+	resurrectWaitGroup sync.WaitGroup
+	closeC             chan struct{}
+	closeDone          uint32
 }
 
 type roundRobinSelector struct {
@@ -103,7 +121,7 @@ func NewConnectionPool(conns []*Connection, selector Selector) (ConnectionPool, 
 	if selector == nil {
 		selector = &roundRobinSelector{curr: -1}
 	}
-	return &statusConnectionPool{live: conns, selector: selector}, nil
+	return &statusConnectionPool{live: conns, selector: selector, closeC: make(chan struct{})}, nil
 }
 
 // Next returns the connection from pool.
@@ -124,6 +142,9 @@ func (cp *singleConnectionPool) connections() []*Connection { return []*Connecti
 
 // Next returns a connection from pool, or an error.
 func (cp *statusConnectionPool) Next() (*Connection, error) {
+	if cp.isClosed() {
+		return nil, errors.New("connection pool is closed")
+	}
 	cp.Lock()
 	defer cp.Unlock()
 
@@ -295,6 +316,44 @@ func (cp *statusConnectionPool) URLs() []*url.URL {
 	return urls
 }
 
+// Close closes the connection pool. After which it is no longer possible to use the pool.
+// It will wait until all pending resurrection routines have successfully been cancelled.
+// Close should only be called once, otherwise it will return an error.
+func (cp *statusConnectionPool) Close(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if atomic.CompareAndSwapUint32(&cp.closeDone, 0, 1) {
+		close(cp.closeC)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			cp.resurrectWaitGroup.Wait()
+		}()
+
+		select {
+		case <-done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	} else {
+		return errors.New("connection pool is already closed")
+	}
+
+}
+
+func (cp *statusConnectionPool) isClosed() bool {
+	select {
+	case <-cp.closeC:
+		return true
+	default:
+		return false
+	}
+}
+
 func (cp *statusConnectionPool) connections() []*Connection {
 	var conns []*Connection
 	conns = append(conns, cp.live...)
@@ -338,22 +397,32 @@ func (cp *statusConnectionPool) scheduleResurrect(c *Connection) {
 		debugLogger.Logf("Resurrect %s (failures=%d, factor=%1.1f, timeout=%s) in %s\n", c.URL, c.Failures, factor, timeout, c.DeadSince.Add(timeout).Sub(time.Now().UTC()).Truncate(time.Second))
 	}
 
-	time.AfterFunc(timeout, func() {
-		cp.Lock()
-		defer cp.Unlock()
+	cp.resurrectWaitGroup.Add(1)
+	go func() {
+		defer cp.resurrectWaitGroup.Done()
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
 
-		c.Lock()
-		defer c.Unlock()
+		select {
+		case <-timer.C:
+			cp.Lock()
+			defer cp.Unlock()
 
-		if !c.IsDead {
-			if debugLogger != nil {
-				debugLogger.Logf("Already resurrected %s\n", c.URL)
+			c.Lock()
+			defer c.Unlock()
+
+			if !c.IsDead {
+				if debugLogger != nil {
+					debugLogger.Logf("Already resurrected %s\n", c.URL)
+				}
+				return
 			}
+
+			cp.resurrect(c, true)
+		case <-cp.closeC:
 			return
 		}
-
-		cp.resurrect(c, true)
-	})
+	}()
 }
 
 // Select returns the connection in a round-robin fashion.

--- a/elastictransport/connection_internal_test.go
+++ b/elastictransport/connection_internal_test.go
@@ -21,9 +21,12 @@
 package elastictransport
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 )
@@ -545,6 +548,145 @@ func TestUpdateConnectionPool(t *testing.T) {
 
 		if len(cp.dead) != 0 {
 			t.Errorf("OnFailure() should not add unknown live connections to dead list")
+		}
+	})
+}
+
+func TestCloseConnectionPool(t *testing.T) {
+	t.Run("CloseConnectionPool", func(t *testing.T) {
+		pool := &statusConnectionPool{
+			live: []*Connection{
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+			},
+			selector: &roundRobinSelector{curr: -1},
+			closeC:   make(chan struct{}),
+		}
+
+		err := pool.Close(t.Context())
+		if err != nil {
+			t.Errorf("Close() returned an error: %v", err)
+		}
+
+		err = pool.Close(t.Context())
+		if err == nil {
+			t.Errorf("Second call to Close() should return an error")
+		} else if !strings.Contains(err.Error(), "already closed") {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("CloseConnectionPool isClosed", func(t *testing.T) {
+		pool := &statusConnectionPool{
+			live: []*Connection{
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+			},
+			selector: &roundRobinSelector{curr: -1},
+			closeC:   make(chan struct{}),
+		}
+
+		if pool.isClosed() {
+			t.Errorf("isClosed() returned true before closing")
+		}
+		err := pool.Close(t.Context())
+		if err != nil {
+			t.Errorf("Close() returned an error: %v", err)
+		}
+		if !pool.isClosed() {
+			t.Errorf("isClosed() returned false after close")
+		}
+	})
+
+	t.Run("CloseConnectionPool abort scheduled resurrect", func(t *testing.T) {
+		deadConn := &Connection{URL: &url.URL{Scheme: "http", Host: "foo3"}, IsDead: true, DeadSince: time.Now()}
+
+		pool := &statusConnectionPool{
+			live: []*Connection{
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+			},
+			dead: []*Connection{
+				deadConn,
+			},
+			selector: &roundRobinSelector{curr: -1},
+			closeC:   make(chan struct{}),
+		}
+
+		pool.scheduleResurrect(deadConn)
+
+		err := pool.Close(t.Context())
+		if err != nil {
+			t.Errorf("Close() returned an error: %v", err)
+		}
+
+		if count := len(pool.live); count != 2 {
+			t.Errorf("Should have two live connections after Close(), got %d", count)
+		}
+
+		if count := len(pool.dead); count != 1 {
+			t.Errorf("Should have one dead connection after Close(), got %d", count)
+		}
+	})
+
+	t.Run("CloseConnectionPool nil context", func(t *testing.T) {
+		pool := &statusConnectionPool{
+			live: []*Connection{
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+			},
+			selector: &roundRobinSelector{curr: -1},
+			closeC:   make(chan struct{}),
+		}
+		err := pool.Close(nil)
+		if err != nil {
+			t.Errorf("Close() returned an error: %v", err)
+		}
+	})
+
+	t.Run("CloseConnectionPool should timeout", func(t *testing.T) {
+		pool := &statusConnectionPool{
+			live: []*Connection{
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+			},
+			selector: &roundRobinSelector{curr: -1},
+			closeC:   make(chan struct{}),
+		}
+		// Add to waitgroup that will never be resolved
+		pool.resurrectWaitGroup.Add(1)
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+		defer cancel()
+
+		err := pool.Close(ctx)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("Close() did not timeout")
+		}
+	})
+
+	t.Run("CloseConnectionPool Next() should error if closed", func(t *testing.T) {
+		pool := &statusConnectionPool{
+			live: []*Connection{
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo1"}},
+				&Connection{URL: &url.URL{Scheme: "http", Host: "foo2"}},
+			},
+			selector: &roundRobinSelector{curr: -1},
+			closeC:   make(chan struct{}),
+		}
+
+		err := pool.Close(t.Context())
+		if err != nil {
+			t.Errorf("Close() returned an error: %v", err)
+		}
+
+		_, err = pool.Next()
+		if err == nil {
+			t.Errorf("Next() returned nil error")
+		} else {
+			if !strings.Contains(err.Error(), "connection pool is closed") {
+				t.Errorf("Next() did not return expected error")
+			}
 		}
 	})
 }

--- a/elastictransport/elastictransport.go
+++ b/elastictransport/elastictransport.go
@@ -20,6 +20,7 @@ package elastictransport
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -34,6 +35,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -54,6 +56,11 @@ type Interface interface {
 // Instrumented allows to retrieve the current transport Instrumentation
 type Instrumented interface {
 	InstrumentationEnabled() Instrumentation
+}
+
+// Closeable allows graceful closing of the underlying transport
+type Closeable interface {
+	Close(context.Context) error
 }
 
 // Config represents the configuration of HTTP client.
@@ -134,8 +141,8 @@ type Client struct {
 	retryOnError          func(*http.Request, error) bool
 	retryBackoff          func(attempt int) time.Duration
 	discoverNodesInterval time.Duration
-	discoverNodesTimer    *time.Timer
 	discoverNodeTimeout   *time.Duration
+	discoverWaitGroup     sync.WaitGroup
 
 	compressRequestBody      bool
 	compressRequestBodyLevel int
@@ -152,6 +159,10 @@ type Client struct {
 	poolFunc  func([]*Connection, Selector) ConnectionPool
 
 	interceptor InterceptorFunc
+
+	// closeC when closed signals the client to close
+	closeC    chan struct{}
+	closeDone uint32
 }
 
 // New creates new transport client.
@@ -247,6 +258,8 @@ func New(cfg Config) (*Client, error) {
 		poolFunc:  cfg.ConnectionPoolFunc,
 
 		instrumentation: cfg.Instrumentation,
+
+		closeC: make(chan struct{}),
 	}
 
 	if len(cfg.Interceptors) > 0 {
@@ -279,9 +292,7 @@ func New(cfg Config) (*Client, error) {
 	}
 
 	if client.discoverNodesInterval > 0 {
-		time.AfterFunc(client.discoverNodesInterval, func() {
-			client.scheduleDiscoverNodes(client.discoverNodesInterval)
-		})
+		client.scheduleDiscoverNodes(client.discoverNodesInterval)
 	}
 
 	if client.compressRequestBodyLevel == 0 {
@@ -299,6 +310,10 @@ func New(cfg Config) (*Client, error) {
 
 // Perform executes the request and returns a response or error.
 func (c *Client) Perform(req *http.Request) (*http.Response, error) {
+	if c.isClosed() {
+		return nil, ErrClosed
+	}
+
 	var (
 		res *http.Response
 		err error
@@ -586,3 +601,81 @@ func (c *Client) logRoundTrip(
 	}
 	c.logger.LogRoundTrip(req, &dupRes, err, start, dur) // errcheck exclude
 }
+
+func (c *Client) isClosed() bool {
+	select {
+	case <-c.closeC:
+		return true
+	default:
+		return false
+	}
+}
+
+// Close marks the elastictransport.Client as closed. After which it is no longer possible to perform requests.
+// It will wait until graceful shutdown of the client or the context.Context deadline is reached.
+// Close should only be called once, otherwise it will return ErrAlreadyClosed.
+func (c *Client) Close(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if atomic.CompareAndSwapUint32(&c.closeDone, 0, 1) {
+		close(c.closeC)
+		wg := sync.WaitGroup{}
+		errChan := make(chan error, 1)
+
+		if closeable, ok := c.pool.(CloseableConnectionPool); ok {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer close(errChan)
+				err := closeable.Close(ctx)
+				if err != nil {
+					errChan <- fmt.Errorf("failed to close connection pool: %w", err)
+				}
+			}()
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.discoverWaitGroup.Wait()
+		}()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			wg.Wait()
+		}()
+
+		select {
+		case <-done:
+			return drainErrChan(errChan)
+		case <-ctx.Done():
+			return errors.Join(ctx.Err(), drainErrChan(errChan))
+		}
+	} else {
+		return ErrAlreadyClosed
+	}
+}
+
+func drainErrChan(ch <-chan error) error {
+	var err error
+	for {
+		select {
+		case errC, open := <-ch:
+			if !open {
+				return err
+			}
+			err = errors.Join(err, errC)
+		default:
+			return err
+		}
+	}
+}
+
+// ErrClosed is returned when the transport is closed.
+var ErrClosed = errors.New("elastictransport is closed")
+
+// ErrAlreadyClosed is returned when the transport is already closed and cannot be closed again.
+var ErrAlreadyClosed = errors.New("elastictransport is already closed")

--- a/elastictransport/instrumentation.go
+++ b/elastictransport/instrumentation.go
@@ -20,13 +20,14 @@ package elastictransport
 import (
 	"bytes"
 	"context"
+	"io"
+	"net/http"
+	"strconv"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	"io"
-	"net/http"
-	"strconv"
 )
 
 const schemaUrl = "https://opentelemetry.io/schemas/1.21.0"


### PR DESCRIPTION
Adds a Close method to the transport which cleans up resources.

* Closes the client gracefully
  * Cancels running and scheduled background DiscoverNodes calls
  * Cancels scheduled connection resurrections
* Forcefully stops the client on context timeout
* Sets a timeout for DiscoverNodesContext calls from within scheduleDiscoverNodes loop to be equal to the DiscoverNodesInterval. DiscoverNodeTimeout is still respected