### PR TITLE
feat: add context-based logger injection, accessor, and discovery pool fix

### DIFF
--- a/elastictransport/discovery.go
+++ b/elastictransport/discovery.go
@@ -140,6 +140,10 @@ func (c *Client) DiscoverNodesContext(ctx context.Context) error {
 		}
 	}
 
+	if ls, ok := c.pool.(loggerSettable); ok {
+		ls.setLogger(c.leveledLogger)
+	}
+
 	return nil
 }
 

--- a/elastictransport/elastictransport.go
+++ b/elastictransport/elastictransport.go
@@ -371,6 +371,13 @@ func (c *Client) Perform(req *http.Request) (*http.Response, error) {
 		err error
 	)
 
+	// Inject the leveled logger into the request context so interceptors
+	// can retrieve it via LoggerFromContext, unless the caller already
+	// attached one (per-request override).
+	if c.leveledLogger != nil && LoggerFromContext(req.Context()) == nil {
+		req = req.WithContext(ContextWithLogger(req.Context(), c.leveledLogger))
+	}
+
 	// Record metrics, when enabled
 	if c.metrics != nil {
 		c.metrics.requests.Add(1)
@@ -545,6 +552,12 @@ func (c *Client) URLs() []*url.URL {
 
 func (c *Client) InstrumentationEnabled() Instrumentation {
 	return c.instrumentation
+}
+
+// LeveledLoggerEnabled returns the configured [LeveledLogger], or nil if
+// leveled logging is not enabled.
+func (c *Client) LeveledLoggerEnabled() LeveledLogger {
+	return c.leveledLogger
 }
 
 func (c *Client) snapshotPool() ConnectionPool {

--- a/elastictransport/elastictransport_internal_test.go
+++ b/elastictransport/elastictransport_internal_test.go
@@ -2251,6 +2251,143 @@ func TestLeveledLogger(t *testing.T) {
 			t.Errorf("Expected response.body in log output, got: %+v", ml.calls)
 		}
 	})
+
+	t.Run("LeveledLoggerEnabled accessor", func(t *testing.T) {
+		ml := &mockLeveledLogger{}
+		u, _ := url.Parse("http://localhost:9200")
+		tp, err := NewClient(WithURLs(u), WithLeveledLogger(ml))
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if tp.LeveledLoggerEnabled() != ml {
+			t.Error("Expected LeveledLoggerEnabled to return the configured logger")
+		}
+
+		tp2, err := NewClient(WithURLs(u))
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if tp2.LeveledLoggerEnabled() != nil {
+			t.Error("Expected LeveledLoggerEnabled to return nil when not configured")
+		}
+	})
+
+	t.Run("Logger injected into request context for interceptors", func(t *testing.T) {
+		ml := &mockLeveledLogger{}
+		u, _ := url.Parse("http://localhost:9200")
+		var ctxLogger LeveledLogger
+
+		tp, err := NewClient(
+			WithURLs(u),
+			WithTransport(&mockTransp{
+				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Status:     "200 OK",
+						StatusCode: 200,
+						Header:     http.Header{},
+						Body:       io.NopCloser(strings.NewReader("")),
+					}, nil
+				},
+			}),
+			WithLeveledLogger(ml),
+			WithInterceptors(func(next RoundTripFunc) RoundTripFunc {
+				return func(req *http.Request) (*http.Response, error) {
+					ctxLogger = LoggerFromContext(req.Context())
+					return next(req)
+				}
+			}),
+		)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		req, _ := http.NewRequest("GET", "/", nil)
+		_, err = tp.Perform(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if ctxLogger != ml {
+			t.Error("Expected interceptor to receive the LeveledLogger from context")
+		}
+	})
+
+	t.Run("Per-request context logger overrides client logger", func(t *testing.T) {
+		clientLogger := &mockLeveledLogger{}
+		requestLogger := &mockLeveledLogger{}
+		u, _ := url.Parse("http://localhost:9200")
+		var ctxLogger LeveledLogger
+
+		tp, err := NewClient(
+			WithURLs(u),
+			WithTransport(&mockTransp{
+				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Status:     "200 OK",
+						StatusCode: 200,
+						Header:     http.Header{},
+						Body:       io.NopCloser(strings.NewReader("")),
+					}, nil
+				},
+			}),
+			WithLeveledLogger(clientLogger),
+			WithInterceptors(func(next RoundTripFunc) RoundTripFunc {
+				return func(req *http.Request) (*http.Response, error) {
+					ctxLogger = LoggerFromContext(req.Context())
+					return next(req)
+				}
+			}),
+		)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		req, _ := http.NewRequest("GET", "/", nil)
+		req = req.WithContext(ContextWithLogger(req.Context(), requestLogger))
+		_, err = tp.Perform(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if ctxLogger != requestLogger {
+			t.Error("Expected per-request logger to override client logger in context")
+		}
+	})
+
+	t.Run("LoggerFromContext returns nil when no logger set", func(t *testing.T) {
+		u, _ := url.Parse("http://localhost:9200")
+		var ctxLogger LeveledLogger = &mockLeveledLogger{} // non-nil sentinel
+
+		tp, err := NewClient(
+			WithURLs(u),
+			WithTransport(&mockTransp{
+				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Status:     "200 OK",
+						StatusCode: 200,
+						Header:     http.Header{},
+						Body:       io.NopCloser(strings.NewReader("")),
+					}, nil
+				},
+			}),
+			WithInterceptors(func(next RoundTripFunc) RoundTripFunc {
+				return func(req *http.Request) (*http.Response, error) {
+					ctxLogger = LoggerFromContext(req.Context())
+					return next(req)
+				}
+			}),
+		)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		req, _ := http.NewRequest("GET", "/", nil)
+		_, err = tp.Perform(req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		if ctxLogger != nil {
+			t.Error("Expected LoggerFromContext to return nil when no logger configured")
+		}
+	})
 }
 
 type trackingLogger struct {

--- a/elastictransport/logger.go
+++ b/elastictransport/logger.go
@@ -20,6 +20,7 @@ package elastictransport
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,6 +31,36 @@ import (
 	"strings"
 	"time"
 )
+
+type loggerContextKey struct{}
+
+// ContextWithLogger returns a copy of ctx with the given [LeveledLogger]
+// attached. Use this to override the transport's logger on a per-request basis,
+// or to make the logger available to [InterceptorFunc] implementations via
+// [LoggerFromContext].
+func ContextWithLogger(ctx context.Context, l LeveledLogger) context.Context {
+	return context.WithValue(ctx, loggerContextKey{}, l)
+}
+
+// LoggerFromContext returns the [LeveledLogger] attached to ctx by
+// [ContextWithLogger], or nil if none is set.
+//
+// This is primarily useful inside [InterceptorFunc] implementations:
+//
+//	interceptor := func(next elastictransport.RoundTripFunc) elastictransport.RoundTripFunc {
+//	    return func(req *http.Request) (*http.Response, error) {
+//	        if logger := elastictransport.LoggerFromContext(req.Context()); logger != nil {
+//	            logger.Debug("interceptor called", "method", req.Method, "url", req.URL.String())
+//	        }
+//	        return next(req)
+//	    }
+//	}
+func LoggerFromContext(ctx context.Context) LeveledLogger {
+	if l, ok := ctx.Value(loggerContextKey{}).(LeveledLogger); ok {
+		return l
+	}
+	return nil
+}
 
 // Logger defines an interface for logging request and response.
 //


### PR DESCRIPTION
> [!NOTE]
> **TL;DR:** Fixes a bug where discovery-created pools lost their logger, adds `ContextWithLogger`/`LoggerFromContext` so interceptors can access the transport logger from `req.Context()`, and adds a `LeveledLoggerEnabled()` accessor on `Client`. Builds on #85.

## Summary

Follow-up to #85 addressing three gaps identified in the LeveledLogger implementation.

## Changes

### 1. Bug fix: Discovery pool logger propagation

Pools created during `DiscoverNodesContext` (when the pool is replaced, not updated in-place) were not receiving the leveled logger via `setLogger`. After the first discovery cycle, all connection-management logs (resurrect, removal, etc.) went silent.

**Fix:** Call `setLogger` on the new pool after creation in `DiscoverNodesContext`, matching the pattern already used in `New()`.

### 2. Context-based logger injection

New exported functions:
- `ContextWithLogger(ctx, logger)` — attaches a `LeveledLogger` to a context
- `LoggerFromContext(ctx)` — retrieves it (returns nil if not set)

The transport auto-injects `client.leveledLogger` into `req.Context()` at the start of `Perform`, making the logger available to `InterceptorFunc` implementations:

```go
interceptor := func(next elastictransport.RoundTripFunc) elastictransport.RoundTripFunc {
    return func(req *http.Request) (*http.Response, error) {
        if logger := elastictransport.LoggerFromContext(req.Context()); logger != nil {
            logger.Debug("before request", "method", req.Method)
        }
        return next(req)
    }
}
```

Per-request overrides are supported — if the caller attaches a logger to the context before calling `Perform`, it takes precedence over the client's logger.

### 3. `LeveledLoggerEnabled()` accessor

Mirrors the existing `InstrumentationEnabled() Instrumentation` pattern. Returns the configured `LeveledLogger`, or nil.

## Files changed

| File | Change |
|---|---|
| `elastictransport/logger.go` | Add `ContextWithLogger`, `LoggerFromContext`, context key type |
| `elastictransport/elastictransport.go` | Inject logger into context in `Perform`, add `LeveledLoggerEnabled()` |
| `elastictransport/discovery.go` | Call `setLogger` on newly created pools |
| `elastictransport/elastictransport_internal_test.go` | 4 new subtests |

## Test plan

- [x] `go build ./...` compiles
- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean
- [x] Accessor returns configured logger / nil
- [x] Interceptor receives logger from context
- [x] Per-request context logger overrides client logger
- [x] No logger in context when none configured
