### PR TITLE
test: de-flake scheduleDiscoverNodes subtest

### DIFF
--- a/elastictransport/discovery_internal_test.go
+++ b/elastictransport/discovery_internal_test.go
@@ -203,26 +203,31 @@ func TestDiscovery(t *testing.T) {
 	})
 
 	t.Run("scheduleDiscoverNodes()", func(t *testing.T) {
-		t.Skip("Skip") // TODO(karmi): Investigate the intermittent failures of this test
-
-		var numURLs int
 		u, _ := url.Parse("http://" + srv.Addr)
 
 		tp, _ := New(Config{URLs: []*url.URL{u}, DiscoverNodesInterval: 10 * time.Millisecond})
+		defer func() { _ = tp.Close(context.Background()) }()
 
 		tp.poolMu.RLock()
-		numURLs = len(tp.pool.URLs())
+		numURLs := len(tp.pool.URLs())
 		tp.poolMu.RUnlock()
 		if numURLs != 1 {
-			t.Errorf("Unexpected number of nodes, want=1, got=%d", numURLs)
+			t.Errorf("Unexpected number of nodes before tick, want=1, got=%d", numURLs)
 		}
 
-		time.Sleep(18 * time.Millisecond) // Wait until (*Client).scheduleDiscoverNodes()
-		tp.poolMu.RLock()
-		numURLs = len(tp.pool.URLs())
-		tp.poolMu.RUnlock()
-		if numURLs != 2 {
-			t.Errorf("Unexpected number of nodes, want=2, got=%d", numURLs)
+		poolSize := func() int {
+			tp.poolMu.RLock()
+			defer tp.poolMu.RUnlock()
+			return len(tp.pool.URLs())
+		}
+
+		deadline := time.Now().Add(2 * time.Second)
+		for poolSize() != 2 {
+
+			if time.Now().After(deadline) {
+				t.Fatalf("scheduleDiscoverNodes did not update pool within 2s, final size=%d", poolSize())
+			}
+			time.Sleep(5 * time.Millisecond)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Unblocks the permanently skipped `scheduleDiscoverNodes()` subtest in [`elastictransport/discovery_internal_test.go`](elastictransport/discovery_internal_test.go) (was disabled with `t.Skip("Skip") // TODO(karmi): Investigate the intermittent failures`).
- Replaces the fixed `time.Sleep(18 * time.Millisecond)` with a bounded poll loop (2s ceiling, 5ms interval) that waits for the discovery tick to update the pool to 2 nodes. The test is now deterministic when passing and has a hard upper bound when failing.
- Adds a `defer tp.Close(...)` so the scheduled discovery goroutine is drained when the subtest exits.

Addresses item (a) of #99.

## Why the original test was flaky

The original code started a client with `DiscoverNodesInterval: 10ms`, slept 18ms, then asserted the pool had grown from 1 to 2 nodes. That window relied on (1) the `time.NewTicker` firing within 8ms of the expected instant, (2) the scheduled goroutine being picked up by the runtime, and (3) an HTTP round-trip to a same-process `http.Server` completing — all within 10ms of margin. On shared CI runners that margin is not reliable, so the test was permanently skipped.

The bounded-poll pattern is the standard fix (equivalent to `testify/assert.Eventually` or `k8s.io/apimachinery/pkg/util/wait.Poll`): the test succeeds as soon as the condition holds, and fails predictably if it doesn't hold within the ceiling.

## Test plan

- [x] `go test -race -run 'TestDiscovery/scheduleDiscoverNodes' ./elastictransport/ -count=50` passes 50/50 locally.
- [x] `go test -race -run 'TestDiscovery' ./elastictransport/` passes (full discovery suite).
- [x] `golangci-lint run` passes.

## Follow-ups

Does not close #99 — fuzz targets and the concurrent-close test (items b and c) will follow in a separate PR.