### PR TITLE
test: add fuzz targets and concurrent close coverage

### DIFF
--- a/elastictransport/close_internal_test.go
+++ b/elastictransport/close_internal_test.go
@@ -1,0 +1,140 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !integration
+// +build !integration
+
+package elastictransport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCloseConcurrent exercises Close racing with many in-flight Perform
+// calls while scheduleDiscoverNodes is actively ticking. The goal is to
+// prove under the race detector that:
+//
+//   - Close returns within its context deadline and drains discoverWaitGroup.
+//   - Every Perform call returns either a *http.Response or ErrClosed,
+//     never a panic, an unexpected error, or a hang.
+//   - A non-zero number of calls observe each outcome, i.e. Close actually
+//     fires mid-traffic rather than before or after.
+func TestCloseConcurrent(t *testing.T) {
+	// Build a /_nodes/http payload that points both nodes back at the
+	// httptest server address; otherwise discovery would replace the pool
+	// with addresses that don't exist and the test would connect-refuse.
+	var serverAddr string
+	nodesTmpl := `{"nodes":{` +
+		`"es1":{"name":"es1","http":{"publish_address":"%s"},"roles":["master","data"]},` +
+		`"es2":{"name":"es2","http":{"publish_address":"%s"},"roles":["master","data"]}` +
+		`}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_nodes/http" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, nodesTmpl, serverAddr, serverAddr)
+			return
+		}
+		// Simulate a small amount of work so Perform calls overlap with Close.
+		time.Sleep(1 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+	serverAddr = strings.TrimPrefix(srv.URL, "http://")
+
+	u, _ := url.Parse(srv.URL)
+	tp, err := New(Config{
+		URLs:                  []*url.URL{u},
+		DiscoverNodesInterval: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %s", err)
+	}
+
+	const workers = 50
+	const testTimeout = 5 * time.Second
+
+	var (
+		okCount     atomic.Int64
+		closedCount atomic.Int64
+		stopLoop    atomic.Bool
+		wg          sync.WaitGroup
+	)
+
+	deadline := time.AfterFunc(testTimeout, func() {
+		stopLoop.Store(true)
+		t.Error("TestCloseConcurrent timed out; probable deadlock")
+	})
+	defer deadline.Stop()
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for !stopLoop.Load() {
+				req, err := http.NewRequest("GET", "/", nil)
+				if err != nil {
+					t.Errorf("NewRequest: %s", err)
+					return
+				}
+				res, err := tp.Perform(req)
+				if err != nil {
+					if errors.Is(err, ErrClosed) {
+						closedCount.Add(1)
+						return
+					}
+					t.Errorf("unexpected Perform error: %v", err)
+					return
+				}
+				_, _ = io.Copy(io.Discard, res.Body)
+				_ = res.Body.Close()
+				okCount.Add(1)
+			}
+		}()
+	}
+
+	// Let traffic build up and discovery tick at least a few times.
+	time.Sleep(20 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := tp.Close(ctx); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Close returned unexpected error: %v", err)
+	}
+
+	wg.Wait()
+	stopLoop.Store(true)
+
+	if okCount.Load() == 0 {
+		t.Errorf("no Perform calls succeeded; Close may have fired before any request completed")
+	}
+	if closedCount.Load() == 0 {
+		t.Errorf("no Perform calls observed ErrClosed; Close may not have taken effect")
+	}
+	t.Logf("ok=%d closed=%d", okCount.Load(), closedCount.Load())
+}

--- a/elastictransport/discovery_internal_test.go
+++ b/elastictransport/discovery_internal_test.go
@@ -720,3 +720,43 @@ func TestDiscoverNodesContextReturnsErrClosedWhenClosedOnEmptyDiscoveredSet(t *t
 		t.Fatalf("DiscoverNodesContext() error mismatch, want=%v, got=%v", ErrClosed, err)
 	}
 }
+
+// FuzzGetNodeURL fuzzes (*Client).getNodeURL. The target parses the
+// publish_address returned by Elasticsearch (`hostname/address:port` or
+// `address:port`, with IPv4, IPv6, or hostnames). The property is simply that
+// parsing must never panic and must always return a non-nil *url.URL for any
+// input, since the production caller assigns the result without nil-checking.
+func FuzzGetNodeURL(f *testing.F) {
+	seeds := []struct {
+		addr   string
+		scheme string
+	}{
+		{"127.0.0.1:9200", "http"},
+		{"localhost/127.0.0.1:9200", "http"},
+		{"es1.local/10.0.0.1:9200", "https"},
+		{"[::1]:9200", "http"},
+		{"[2001:db8::1]:9200", "https"},
+		{"host/[2001:db8::1]:9200", "https"},
+		{"[fe80::1%25eth0]:9200", "http"},
+		{"es-node1:9200", "http"},
+		{"", "http"},
+		{"/:", "http"},
+		{"weirdhost", "http"},
+		{"host/", "http"},
+		{"/addr:1", "http"},
+		{":", ""},
+	}
+	for _, s := range seeds {
+		f.Add(s.addr, s.scheme)
+	}
+
+	c := &Client{}
+	f.Fuzz(func(t *testing.T, addr, scheme string) {
+		node := nodeInfo{}
+		node.HTTP.PublishAddress = addr
+		u := c.getNodeURL(node, scheme)
+		if u == nil {
+			t.Fatalf("getNodeURL returned nil for addr=%q scheme=%q", addr, scheme)
+		}
+	})
+}

--- a/elastictransport/discovery_internal_test.go
+++ b/elastictransport/discovery_internal_test.go
@@ -760,3 +760,46 @@ func FuzzGetNodeURL(f *testing.F) {
 		}
 	})
 }
+
+// FuzzParseNodesInfo fuzzes the JSON decode path that getNodesInfo applies to
+// the response of /_nodes/http: a generic envelope into
+// map[string]json.RawMessage, then the "nodes" entry into map[string]nodeInfo.
+// The property is that the decode must never panic (errors are surfaced via
+// the return value) and that any nodeInfo produced can be passed through
+// getNodeURL without panicking.
+func FuzzParseNodesInfo(f *testing.F) {
+	for _, name := range []string{"testdata/nodes.info.json", "testdata/nodes.info.ipv6.json"} {
+		data, err := os.ReadFile(name)
+		if err != nil {
+			f.Fatalf("read seed %s: %s", name, err)
+		}
+		f.Add(data)
+	}
+	// Minimal shapes that exercise edge cases in the envelope decode.
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"nodes": null}`))
+	f.Add([]byte(`{"nodes": {}}`))
+	f.Add([]byte(`{"nodes": {"es1": {"http": {"publish_address": ""}}}}`))
+	f.Add([]byte(``))
+
+	c := &Client{}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var env map[string]json.RawMessage
+		if err := json.NewDecoder(bytes.NewReader(data)).Decode(&env); err != nil {
+			return
+		}
+		raw, ok := env["nodes"]
+		if !ok {
+			return
+		}
+		var nodes map[string]nodeInfo
+		if err := json.Unmarshal(raw, &nodes); err != nil {
+			return
+		}
+		for _, node := range nodes {
+			if u := c.getNodeURL(node, "http"); u == nil {
+				t.Fatalf("getNodeURL returned nil for publish_address=%q", node.HTTP.PublishAddress)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Three independent commits adding test coverage recommended by #99:

- **FuzzGetNodeURL** — fuzzes `(*Client).getNodeURL`, which parses the `publish_address` returned by Elasticsearch. `publish_address` accepts several shapes (`address:port`, `hostname/address:port`, IPv4/IPv6 literals with zone IDs, bare hostnames). The production caller assigns the result without nil-checking, so the property is: parsing must never panic and must always return a non-nil `*url.URL`.
- **FuzzParseNodesInfo** — fuzzes the JSON decode path used by `(*Client).getNodesInfo` for the `/_nodes/http` response: generic envelope decode into `map[string]json.RawMessage`, then the `"nodes"` entry into `map[string]nodeInfo`. Any decoded node is then passed through `getNodeURL`. Seed corpus is the existing `testdata/nodes.info.json` and `testdata/nodes.info.ipv6.json` plus minimal envelope shapes.
- **TestCloseConcurrent** (new `elastictransport/close_internal_test.go`) — exercises `Close` racing with many in-flight `Perform` calls while `scheduleDiscoverNodes` is actively ticking, under the race detector. Spins 50 goroutines that each loop `Perform` until they see `ErrClosed`, fires `Close` mid-traffic, and asserts that every `Perform` returns either a `*http.Response` or `ErrClosed` (never a panic, a hang, or an unexpected error type), that `Close` itself returns within its ctx deadline, and that both outcomes are observed at least once. A deadlock watchdog fails the test if goroutines don't drain within 5s.

Addresses items (b) and (c) of #99. Item (a) (de-flaking the skipped `scheduleDiscoverNodes` test) ships separately in #102.

## Why no dedicated fuzzing CI job

The existing `go test -v -race ./...` already runs each fuzz target's seed corpus as regular subtests, which gives us regression coverage for known-tricky inputs without adding CI time or flakiness risk. A dedicated `-fuzz=...` nightly job is a natural follow-up once these targets have proven their value.

## Local fuzzing results

- `go test -fuzz=FuzzGetNodeURL -fuzztime=10s` — ~1.8M execs, no crashing inputs.
- `go test -fuzz=FuzzParseNodesInfo -fuzztime=10s` — ~280k execs, 76 new interesting inputs discovered, no crashing inputs.

## Test plan

- [x] `go test -race -run '^Fuzz' ./elastictransport/` passes (seed corpus).
- [x] `go test -race -run TestCloseConcurrent ./elastictransport/ -count=100` passes 100/100.
- [x] `go test -race ./elastictransport/...` passes (full suite).
- [x] `golangci-lint run` passes (via pre-commit).