### PR TITLE
fix: fall back to configured seed URLs when pool is exhausted during discovery

### DIFF
--- a/elastictransport/discovery.go
+++ b/elastictransport/discovery.go
@@ -171,10 +171,16 @@ func (c *Client) getNodesInfo(ctx context.Context) ([]nodeInfo, error) {
 		if err == nil {
 			return nodes, nil
 		}
-		if onFailErr := pool.OnFailure(conn); onFailErr != nil && c.leveledLogger != nil {
-			c.leveledLogger.Warn(ctx, "discovery: pool.OnFailure error", "error", onFailErr)
-		}
 		primaryErr = fmt.Errorf("pool conn %s: %w", conn.URL.Redacted(), err)
+		// Don't mark the node as failed when the request was canceled by our own
+		// context (e.g. client Close, caller timeout) — that's a client-side
+		// signal, not a node fault, and scheduling a resurrect during Close
+		// races with pool shutdown.
+		if ctx.Err() == nil {
+			if onFailErr := pool.OnFailure(conn); onFailErr != nil && c.leveledLogger != nil {
+				c.leveledLogger.Warn(ctx, "discovery: pool.OnFailure error", "error", onFailErr)
+			}
+		}
 	}
 
 	if err := ctx.Err(); err != nil {

--- a/elastictransport/discovery.go
+++ b/elastictransport/discovery.go
@@ -152,10 +152,7 @@ func (c *Client) getNodesInfo(ctx context.Context) ([]nodeInfo, error) {
 		return nil, errors.New("no URLs configured")
 	}
 
-	var (
-		out    []nodeInfo
-		scheme = c.urls[0].Scheme
-	)
+	scheme := c.urls[0].Scheme
 
 	var cancel context.CancelFunc
 	if c.discoverNodeTimeout != nil {
@@ -163,49 +160,68 @@ func (c *Client) getNodesInfo(ctx context.Context) ([]nodeInfo, error) {
 		defer cancel()
 	}
 
+	pool := c.snapshotPool()
+	conn, poolErr := pool.Next()
+	if poolErr == nil {
+		return c.fetchNodesInfo(ctx, conn.URL, scheme)
+	}
+
+	if c.leveledLogger != nil {
+		c.leveledLogger.Debug(ctx, "discovery: pool exhausted, falling back to seed URLs", "error", poolErr)
+	}
+
+	errs := []error{fmt.Errorf("pool: %w", poolErr)}
+	for _, u := range c.urls {
+		nodes, err := c.fetchNodesInfo(ctx, u, scheme)
+		if err == nil {
+			if c.leveledLogger != nil {
+				c.leveledLogger.Debug(ctx, "discovery: seed URL fallback succeeded", "url", u.Redacted())
+			}
+			return nodes, nil
+		}
+		errs = append(errs, fmt.Errorf("seed %s: %w", u.Redacted(), err))
+	}
+
+	return nil, fmt.Errorf("discovery: all seed URLs failed: %w", errors.Join(errs...))
+}
+
+func (c *Client) fetchNodesInfo(ctx context.Context, u *url.URL, scheme string) ([]nodeInfo, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", "/_nodes/http", nil)
 	if err != nil {
-		return out, err
+		return nil, err
 	}
 
-	pool := c.snapshotPool()
-	conn, err := pool.Next()
-	// TODO(karmi): If no connection is returned, fallback to original URLs
-	if err != nil {
-		return out, err
-	}
-
-	c.setReqURL(conn.URL, req)
-	c.setReqAuth(conn.URL, req)
+	c.setReqURL(u, req)
+	c.setReqAuth(u, req)
 	c.setReqUserAgent(req)
 	c.setReqGlobalHeader(req)
 
 	res, err := c.roundTrip(req)
 	if err != nil {
-		return out, err
+		return nil, err
 	}
 	defer func(Body io.ReadCloser) {
-		err := Body.Close()
-		if err != nil && c.leveledLogger != nil {
+		if err := Body.Close(); err != nil && c.leveledLogger != nil {
 			c.leveledLogger.Warn(ctx, "error closing response body", "error", err)
 		}
 	}(res.Body)
 
 	if res.StatusCode > 200 {
 		body, _ := io.ReadAll(res.Body)
-		return out, fmt.Errorf("server error: %s: %s", res.Status, body)
+		return nil, fmt.Errorf("server error: %s: %s", res.Status, body)
 	}
 
 	var env map[string]json.RawMessage
 	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
-		return out, err
+		return nil, err
 	}
 
 	var nodes map[string]nodeInfo
 	if err := json.Unmarshal(env["nodes"], &nodes); err != nil {
-		return out, err
+		return nil, err
 	}
 
+	out := make([]nodeInfo, 0, len(nodes))
 	for id, node := range nodes {
 		node.ID = id
 		node.URL = c.getNodeURL(node, scheme)

--- a/elastictransport/discovery.go
+++ b/elastictransport/discovery.go
@@ -162,16 +162,35 @@ func (c *Client) getNodesInfo(ctx context.Context) ([]nodeInfo, error) {
 
 	pool := c.snapshotPool()
 	conn, poolErr := pool.Next()
-	if poolErr == nil {
-		return c.fetchNodesInfo(ctx, conn.URL, scheme)
+
+	var primaryErr error
+	if poolErr != nil {
+		primaryErr = fmt.Errorf("pool: %w", poolErr)
+	} else {
+		nodes, err := c.fetchNodesInfo(ctx, conn.URL, scheme)
+		if err == nil {
+			return nodes, nil
+		}
+		if onFailErr := pool.OnFailure(conn); onFailErr != nil && c.leveledLogger != nil {
+			c.leveledLogger.Warn(ctx, "discovery: pool.OnFailure error", "error", onFailErr)
+		}
+		primaryErr = fmt.Errorf("pool conn %s: %w", conn.URL.Redacted(), err)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("discovery: %w: %w", err, primaryErr)
 	}
 
 	if c.leveledLogger != nil {
-		c.leveledLogger.Debug(ctx, "discovery: pool exhausted, falling back to seed URLs", "error", poolErr)
+		c.leveledLogger.Debug(ctx, "discovery: primary attempt failed, falling back to seed URLs", "error", primaryErr)
 	}
 
-	errs := []error{fmt.Errorf("pool: %w", poolErr)}
+	errs := []error{primaryErr}
 	for _, u := range c.urls {
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, err)
+			break
+		}
 		nodes, err := c.fetchNodesInfo(ctx, u, scheme)
 		if err == nil {
 			if c.leveledLogger != nil {

--- a/elastictransport/discovery_internal_test.go
+++ b/elastictransport/discovery_internal_test.go
@@ -831,6 +831,78 @@ func TestDiscoverNodesContextReturnsJoinedErrorWhenPoolAndSeedsFail(t *testing.T
 	}
 }
 
+func TestDiscoverNodesContextFallsBackToSeedURLsWhenPoolConnFails(t *testing.T) {
+	payload := []byte(`{
+		"nodes": {
+			"es1": {"roles": ["data"], "http": {"publish_address": "es1:9200"}}
+		}
+	}`)
+
+	deadNode, _ := url.Parse("http://deadnode:9200")
+	seed, _ := url.Parse("http://liveseed:9200")
+
+	var (
+		mu          sync.Mutex
+		visited     []string
+		onFailCount int
+	)
+
+	tp, _ := New(Config{
+		URLs: []*url.URL{seed},
+		Transport: &mockTransp{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				mu.Lock()
+				visited = append(visited, req.URL.Host)
+				mu.Unlock()
+
+				if req.URL.Host == deadNode.Host {
+					return nil, &mockNetError{error: errors.New("connection refused")}
+				}
+				return &http.Response{
+					Status:        "200 OK",
+					StatusCode:    200,
+					ContentLength: int64(len(payload)),
+					Header:        map[string][]string{"Content-Type": {"application/json"}},
+					Body:          io.NopCloser(bytes.NewReader(payload)),
+				}, nil
+			},
+		},
+	})
+
+	tp.poolMu.Lock()
+	tp.pool = &spyPool{conn: &Connection{URL: deadNode}, onFailure: func() { onFailCount++ }}
+	tp.poolMu.Unlock()
+
+	if err := tp.DiscoverNodesContext(context.Background()); err != nil {
+		t.Fatalf("DiscoverNodesContext() unexpected error: %s", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(visited) != 2 || visited[0] != deadNode.Host || visited[1] != seed.Host {
+		t.Fatalf("Expected visit order [%s, %s], got %v", deadNode.Host, seed.Host, visited)
+	}
+	if onFailCount != 1 {
+		t.Fatalf("Expected pool.OnFailure to be called exactly once, got %d", onFailCount)
+	}
+}
+
+// spyPool returns a single connection and records OnFailure calls.
+type spyPool struct {
+	conn      *Connection
+	onFailure func()
+}
+
+func (p *spyPool) Next() (*Connection, error) { return p.conn, nil }
+func (p *spyPool) OnSuccess(*Connection) error { return nil }
+func (p *spyPool) OnFailure(*Connection) error {
+	if p.onFailure != nil {
+		p.onFailure()
+	}
+	return nil
+}
+func (p *spyPool) URLs() []*url.URL { return []*url.URL{p.conn.URL} }
+
 // FuzzGetNodeURL fuzzes (*Client).getNodeURL. The target parses the
 // publish_address returned by Elasticsearch (`hostname/address:port` or
 // `address:port`, with IPv4, IPv6, or hostnames). The property is simply that

--- a/elastictransport/discovery_internal_test.go
+++ b/elastictransport/discovery_internal_test.go
@@ -33,6 +33,8 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -723,6 +725,109 @@ func TestDiscoverNodesContextReturnsErrClosedWhenClosedOnEmptyDiscoveredSet(t *t
 	err := tp.DiscoverNodesContext(context.Background())
 	if !errors.Is(err, ErrClosed) {
 		t.Fatalf("DiscoverNodesContext() error mismatch, want=%v, got=%v", ErrClosed, err)
+	}
+}
+
+// exhaustedPool is a ConnectionPool that always returns an error from Next,
+// simulating a pool whose connections are all marked dead or otherwise
+// unavailable.
+type exhaustedPool struct{}
+
+func (exhaustedPool) Next() (*Connection, error) {
+	return nil, errors.New("no connection available")
+}
+func (exhaustedPool) OnSuccess(*Connection) error { return nil }
+func (exhaustedPool) OnFailure(*Connection) error { return nil }
+func (exhaustedPool) URLs() []*url.URL            { return nil }
+
+func TestDiscoverNodesContextFallsBackToSeedURLsWhenPoolExhausted(t *testing.T) {
+	payload := []byte(`{
+		"nodes": {
+			"es1": {"roles": ["data"], "http": {"publish_address": "es1:9200"}},
+			"es2": {"roles": ["data"], "http": {"publish_address": "es2:9200"}}
+		}
+	}`)
+
+	deadSeed, _ := url.Parse("http://deadseed:9200")
+	liveSeed, _ := url.Parse("http://liveseed:9200")
+
+	var (
+		mu      sync.Mutex
+		visited []string
+	)
+
+	tp, _ := New(Config{
+		URLs: []*url.URL{deadSeed, liveSeed},
+		Transport: &mockTransp{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				mu.Lock()
+				visited = append(visited, req.URL.Host)
+				mu.Unlock()
+
+				if req.URL.Host == deadSeed.Host {
+					return nil, &mockNetError{error: errors.New("connection refused")}
+				}
+				return &http.Response{
+					Status:        "200 OK",
+					StatusCode:    200,
+					ContentLength: int64(len(payload)),
+					Header:        map[string][]string{"Content-Type": {"application/json"}},
+					Body:          io.NopCloser(bytes.NewReader(payload)),
+				}, nil
+			},
+		},
+	})
+
+	tp.poolMu.Lock()
+	tp.pool = exhaustedPool{}
+	tp.poolMu.Unlock()
+
+	if err := tp.DiscoverNodesContext(context.Background()); err != nil {
+		t.Fatalf("DiscoverNodesContext() unexpected error: %s", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(visited) < 2 || visited[0] != deadSeed.Host || visited[1] != liveSeed.Host {
+		t.Fatalf("Expected seed URLs tried in order [%s, %s], got %v", deadSeed.Host, liveSeed.Host, visited)
+	}
+
+	pool, ok := tp.pool.(*statusConnectionPool)
+	if !ok {
+		t.Fatalf("Unexpected pool type after discovery: %T", tp.pool)
+	}
+	if len(pool.live) != 2 {
+		t.Fatalf("Unexpected number of live connections, want=2, got=%d", len(pool.live))
+	}
+}
+
+func TestDiscoverNodesContextReturnsJoinedErrorWhenPoolAndSeedsFail(t *testing.T) {
+	u1, _ := url.Parse("http://seed1:9200")
+	u2, _ := url.Parse("http://seed2:9200")
+
+	tp, _ := New(Config{
+		URLs: []*url.URL{u1, u2},
+		Transport: &mockTransp{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				return nil, &mockNetError{error: fmt.Errorf("dial %s: refused", req.URL.Host)}
+			},
+		},
+	})
+
+	tp.poolMu.Lock()
+	tp.pool = exhaustedPool{}
+	tp.poolMu.Unlock()
+
+	err := tp.DiscoverNodesContext(context.Background())
+	if err == nil {
+		t.Fatalf("DiscoverNodesContext() expected error, got nil")
+	}
+
+	msg := err.Error()
+	for _, want := range []string{"discovery", "pool", "no connection available", "seed1:9200", "seed2:9200"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Expected error to contain %q, got: %s", want, msg)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #93.

Discovery now falls back to the configured seed URLs when the pool-based fetch of `/_nodes/http` fails, giving the client a chance to self-heal when every discovered node is unreachable but a seed URL is still up.

- `getNodesInfo` attempts the pool-selected connection first.
- If `pool.Next()` errors, **or** the fetch via the pool connection fails (network error, non-2xx, decode error), each `c.urls` entry is tried in order. On pool-connection failure we also call `pool.OnFailure(conn)` so the pool state stays accurate.
- First seed URL that returns a valid response wins; the remaining seeds are skipped.
- On total failure the pool/pool-conn error is joined with each seed error via `errors.Join` so the root cause is preserved and still unwrappable via `errors.Is`/`errors.As`.
- Fallback short-circuits on context cancellation to avoid hammering seed URLs when the parent context is already done.
- Happy path unchanged: when the pool-selected connection succeeds, no seed URLs are touched.
- Extracted the single-URL fetch logic into `fetchNodesInfo` so the pool and fallback paths share one implementation.

## Discussion point: why fall back on request failure, not just on `pool.Next()` error

The issue text describes the trigger as `pool.Next()` returning an error "for example every node has been marked dead and is waiting for resurrection". In practice that's not how `statusConnectionPool.Next()` behaves today:

1. Live connections exist -> pick one.
2. No live, but dead exist -> force-resurrect the last dead one and return it.
3. Error **only** when both `live` and `dead` are empty (or the pool is closed, or `resurrect` itself errors).

`scheduleResurrect` also auto-resurrects dead nodes after `defaultResurrectTimeoutInitial` (60s, doubling up to ~32min).

So "every node marked dead" doesn't produce a `pool.Next()` error - `Next()` hands back a force-resurrected dead node, and the real failure surfaces inside `c.roundTrip(req)` when that node is actually unreachable. A fix that only kicks in on `pool.Next()` errors would miss the scenario the issue is trying to solve and would only help the degenerate "pool has zero connections" case.

Caveat of the broader trigger: on a transient network blip where a pool node fails a single discovery request, we now walk every seed URL before giving up, which can amplify latency. I think that's acceptable for the discovery path (runs on a long interval, off the hot request path), but happy to narrow the trigger if reviewers prefer.

## Test plan

- [x] `go test -v -race ./...` passes
- [x] `go vet ./...` clean
- [x] Unit test: pool exhausted + first seed down + second seed up -> discovery succeeds, pool repopulated, seeds tried in configured order
- [x] Unit test: pool exhausted + all seeds down -> returns a joined error referencing the pool error and every seed host
- [x] Unit test: pool returns a (dead) connection whose fetch fails + seed succeeds -> `pool.OnFailure` called exactly once, seed URL contacted after the dead node, discovery succeeds
