### PR TITLE
ci: enable PR auto-labeling and add changelog labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -57,6 +57,10 @@
   description: "New feature"
   color: "#5ba4cf"
 
+- name: "Category: Maintenance"
+  description: "Internal maintenance (tests, CI, refactor, chore, revert); excluded from release notes"
+  color: "#5ba4cf"
+
 - name: "Category: Not an issue"
   description: "This doesn't seem right"
   color: "#5ba4cf"
@@ -68,6 +72,14 @@
   color: "#5ba4cf"
   aliases:
     - "question"
+
+- name: "breaking change"
+  description: 'Introduces a breaking change (applied automatically from a "!" in the PR title)'
+  color: "#b60205"
+
+- name: "changelog:skip"
+  description: "Exclude this PR from generated release notes"
+  color: "#cfd3d7"
 
 - name: "good first issue"
   color: "#7057ff"

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -12,4 +12,5 @@ jobs:
         uses: ytanikin/pr-conventional-commits@1.4.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
-          add_label: "false"
+          add_label: "true"
+          custom_labels: '{"feat": "Category: Feature", "fix": "Category: Bug", "perf": "Category: Enhancement", "docs": "Area: Documentation", "test": "Category: Maintenance", "ci": "Category: Maintenance", "refactor": "Category: Maintenance", "chore": "Category: Maintenance", "revert": "Category: Maintenance"}'


### PR DESCRIPTION
## What

Enable PR auto-labeling in the title checker and add the labels needed to support docs-builder changelog generation (groundwork for #83).

## Changes

**`.github/workflows/pr-title-checker.yml`**
- `add_label: "false"` → `"true"`, with a `custom_labels` map so the conventional-commit type drives an existing repo label:

  | Type | Label |
  | --- | --- |
  | feat | Category: Feature |
  | fix | Category: Bug |
  | perf | Category: Enhancement |
  | docs | Area: Documentation |
  | test / ci / refactor / chore / revert | Category: Maintenance |
  | (`!` in title) | + breaking change |

**`.github/labels.yml`** adds three labels:
- `Category: Maintenance` — managed target for non-user-facing types.
- `breaking change` — the exact literal name the action applies on `!` titles. Defined here so `sync-labels.yml` (`delete-other-labels: true`) keeps it and the action does not auto-create it with a hashed color.
- `changelog:skip` — a **manual-only** exclusion label, deliberately kept out of `custom_labels`.

## Why the mapping targets matter

`sync-labels.yml` runs with `delete-other-labels: true`, so every label the auto-labeler applies must exist in `labels.yml`, otherwise it would be deleted. All mapped targets are defined.

## Why `changelog:skip` is not in `custom_labels`

`ytanikin/pr-conventional-commits` treats every `custom_labels` value as a *managed* label and strips any managed label that does not match the PR's current type on each run. Keeping `changelog:skip` out of the map leaves it unmanaged, so maintainers can apply it to any PR (including `feat:`/`fix:`) to suppress its release note, and it will not be stripped on subsequent title edits.

## Follow-up (when #83 lands)

Wire `docs/changelog.yml` to exclude both labels and recognize the breaking type:

```yaml
rules:
  create:
    exclude: "changelog:skip, Category: Maintenance"
pivot:
  types:
    breaking-change: "breaking change"
```

## Test plan

- [ ] Open a test PR with a `feat:` title → receives `Category: Feature`.
- [ ] Change it to `chore:` → label updates to `Category: Maintenance`.
- [ ] Use a `feat!:` title → receives `Category: Feature` + `breaking change`.
- [ ] Manually add `changelog:skip` to a `feat:` PR, then push a title edit → `changelog:skip` persists.
- [ ] Trigger Sync labels (or merge) → new labels created, none of the mapped targets deleted.
