### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  pull-requests: write
+
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
InfoSec is changing GITHUB_TOKEN default permissions from read/write to read-only on July 15th. Adding explicit `permissions` blocks to all workflows that require write access.

- `pr-title-checker.yml`: adds `pull-requests: write` (required by `ytanikin/pr-conventional-commits` with `add_label: "true"`)